### PR TITLE
Fix makefile to properly checkout otp and build it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: build codegen ct submodule
+.PHONY: build codegen ct submodule otp
 
 build: otp codegen
-	cargo build
+	cargo +nightly build
 
 build_tests: submodule
 	cd priv && $(MAKE)
@@ -13,10 +13,10 @@ ct: build
 	mkdir tmp; cd tmp && ../target/debug/ct_run 1 2 3 -erl_args 4 5 6
 
 run: build build_tests
-	cargo run --bin erlexec
+	cargo +nightly run --bin erlexec
 
 test: build build_tests
-	RUST_BACKTRACE=1 cargo run --bin ct_run
+	RUST_BACKTRACE=1 cargo +nightly run --bin ct_run
 
 # Graphical user inteface for GDB - Gede
 .PHONY: test-gede
@@ -24,5 +24,5 @@ test-gede: build
 	RUST_BACKTRACE=1 gede --args target/debug/ct_run
 
 otp:
-	git submodule update && cd otp && MAKE_FLAGS=-j8 ./otp_build setup
+	git submodule init && git submodule update && cd otp && MAKE_FLAGS=-j8 ./otp_build setup
 


### PR DESCRIPTION
The Makefile didn't initialize the submodules and otp was not set to a `PHONY` target so was never build when running `make`